### PR TITLE
Remove padding for small screens

### DIFF
--- a/src/themes/style.css
+++ b/src/themes/style.css
@@ -30,6 +30,12 @@
   }
 }
 
+@media screen and (max-width: 720px) {
+  main {
+    padding: 0px !important;
+  }
+}
+
 html {
   font-size: 16px;
 }


### PR DESCRIPTION
Especially on phones the padding around the paste content is significant. Therefore this patch removes the padding if the screen is small.